### PR TITLE
Jameson/Publish Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,10 @@
     "test": "vitest run",
     "i18n": "node scripts/i18n.js",
     "logBuildDate": "echo 'Last build: '$(date \"+%c\") | tee ./dist/lastBuild.txt",
-    "prepublish:patch": "npm run test && npm run build",
-    "prepublish:minor": "npm run test && npm run build",
-    "prepublish:major": "npm run test && npm run build",
-    "publish:patch": "npm version patch && git push && git push origin --tags && npm publish",
-    "publish:minor": "npm version minor && git push && git push origin --tags && npm publish",
-    "publish:major": "npm version major && git push && git push origin --tags && npm publish"
+    "testAndBuild": "npm run test && npm run build",
+    "publish:patch": "npm run testAndBuild && npm version patch && git push && git push origin --tags && npm publish",
+    "publish:minor": "npm run testAndBuild && npm version minor && git push && git push origin --tags && npm publish",
+    "publish:major": "npm run testAndBuild && npm version major && git push && git push origin --tags && npm publish"
   },
   "dependencies": {
     "@emotion/react": "^11.13.0",


### PR DESCRIPTION
#### Changes

- Created `logBuildDate` script that now runs after all builds.
  - This script creates a file `./dist/lastBuild.txt` with the current date and time.
- Create three prepublish scripts. One for each version type. These scripts will run before publishing.
  - Each script runs the tests and then builds.
- Running `npm run test` now only runs the tests one time instead of watching.
- Created three publish scripts. One for each version type. `publish:patch`, `publish:minor`, `publish:major`
  - Each script bumps the version, pushes the changes including tags, and publishes with NPM.
  
Now after merging, you check out `master` then run **one** of the following scripts depending on changes:
```bash
npm run publish:patch
npm run publish:minor
npm run publish:major
```