### PR TITLE
Get the currentMember directly from state on the OAuthDefault page

### DIFF
--- a/src/views/oauth/OAuthDefault.js
+++ b/src/views/oauth/OAuthDefault.js
@@ -19,6 +19,7 @@ import { getDelay } from 'src/utilities/getDelay'
 import useAnalyticsPath from 'src/hooks/useAnalyticsPath'
 import useAnalyticsEvent from 'src/hooks/useAnalyticsEvent'
 import { AnalyticEvents, PageviewInfo } from 'src/const/Analytics'
+import { getCurrentMember } from 'src/redux/selectors/Connect'
 
 export const OAuthDefault = (props) => {
   useAnalyticsPath(...PageviewInfo.CONNECT_OAUTH_INSTRUCTIONS, {
@@ -32,6 +33,8 @@ export const OAuthDefault = (props) => {
   )
   const isOauthLoading = useSelector((state) => state.connect.isOauthLoading)
   const oauthURL = useSelector((state) => state.connect.oauthURL)
+  const currentMember = useSelector((state) => getCurrentMember(state))
+
   const tokens = useTokens()
   const styles = getStyles(tokens)
 
@@ -71,7 +74,7 @@ export const OAuthDefault = (props) => {
             sendPosthogEvent(AnalyticEvents.OAUTH_DEFAULT_GO_TO_INSTITUTION, {
               institution_guid: props.institution.guid,
               institution_name: props.institution.name,
-              member_guid: sha256(props.currentMember.guid),
+              member_guid: sha256(currentMember.guid),
             })
             props.onSignInClick()
           }}
@@ -88,7 +91,6 @@ export const OAuthDefault = (props) => {
 }
 
 OAuthDefault.propTypes = {
-  currentMember: PropTypes.object.isRequired,
   institution: PropTypes.object.isRequired,
   onSignInClick: PropTypes.func.isRequired,
   selectedInstructionalData: PropTypes.object.isRequired,

--- a/src/views/oauth/OAuthStep.js
+++ b/src/views/oauth/OAuthStep.js
@@ -272,7 +272,6 @@ export const OAuthStep = React.forwardRef((props, navigationRef) => {
     return (
       <StickyComponentContainer footer={footer} ref={containerRef}>
         <OAuthDefault
-          currentMember={member}
           institution={institution}
           onSignInClick={onSignInClick}
           selectedInstructionalData={selectedInstructionalData}


### PR DESCRIPTION
This is an attempt at solving this HB: https://app.honeybadger.io/projects/121858/faults/114499014/01JCC965MKDXYKF8NBXXKSA9DJ?q=input+is+invalid+type

Compare to: https://gitlab.com/mxtechnologies/mx/connect-widget/-/merge_requests/239/diffs

#### Testing instructions

Make sure OAuth works, loading directing to an institution, or clicking into one