### PR TITLE
Cmwimo/CT-1067

### DIFF
--- a/src/views/manualAccount/ManualAccountConnect.js
+++ b/src/views/manualAccount/ManualAccountConnect.js
@@ -40,7 +40,7 @@ export const ManualAccountConnect = React.forwardRef((props, ref) => {
         if (state.showSuccess) {
           return false
         }
-        return true
+        return menuRef.current || formRef.current
       },
     }
   }, [state])


### PR DESCRIPTION
Issue: [https://mxcom.atlassian.net/browse/CT-1067](https://mxcom.atlassian.net/browse/CT-1067)

If for some reasons, ManualAccountForm component takes a bit to mount and the user clicks the Global nav back button, an error will be thrown because the ref passed to it will stay as null. This MR fix that issue.

### Testing instructions

Ensure Manual Account flow still works as expected.
