### PR TITLE
Jameson/CT-1118

### DIFF
--- a/src/views/oauth/OAuthStep.js
+++ b/src/views/oauth/OAuthStep.js
@@ -178,7 +178,7 @@ export const OAuthStep = React.forwardRef((props, navigationRef) => {
     })
 
     if (!is_mobile_webview && config?.oauth_referral_source === REFERRAL_SOURCES.BROWSER) {
-      oauthWindow.current = window.open(oauthURL)
+      oauthWindow.current = window.open(oauthURL, '_blank', 'noopener')
     }
 
     setIsWaitingForOAuth(true)


### PR DESCRIPTION
#### Changes
- Added the `noopener` `windowFeature` to `window.open` on the OAuth step.

#### Testing instructions
- Manually test the OAuth flow using:
  - SDK
  - Browser
- Run integration tests.
- Link to MXConnect and run E2E tests.