### PR TITLE
Prevent OAuth from using a previously connected member

### DIFF
--- a/src/const/apiProviderMock.ts
+++ b/src/const/apiProviderMock.ts
@@ -11,7 +11,7 @@ import {
   SEARCHED_INSTITUTIONS,
 } from 'src/services/mockedData'
 export const apiValue: ApiContextTypes = {
-  addMember: () => Promise.resolve(member.member),
+  addMember: () => Promise.resolve(member),
   deleteMember: () => Promise.resolve(),
   getMemberCredentials: () => Promise.resolve(memberCredentialsData.credentials),
   loadMembers: () => Promise.resolve([member.member]),

--- a/src/context/ApiContext.tsx
+++ b/src/context/ApiContext.tsx
@@ -9,7 +9,7 @@ export type ApiContextTypes = {
     addMember: object,
     config: ClientConfigType,
     isHuman: boolean,
-  ) => Promise<MemberResponseType>
+  ) => Promise<{ member: MemberResponseType }>
   deleteMember: (member: MemberDeleteType) => Promise<void>
   getMemberCredentials: (memberGuid: string) => Promise<CredentialResponseType[]>
   loadMemberByGuid?: (guid: string) => Promise<MemberResponseType>
@@ -92,7 +92,7 @@ export const defaultApiValue: ApiContextTypes = {
   // Accounts
   createAccount: () => Promise.resolve({} as AccountResponseType),
   // Members
-  addMember: () => Promise.resolve({} as MemberResponseType),
+  addMember: () => Promise.resolve({} as { member: MemberResponseType }),
   deleteMember: () => Promise.resolve(),
   getMemberCredentials: () => Promise.resolve([] as CredentialResponseType[]),
   loadMemberByGuid: () => Promise.resolve({} as MemberResponseType),

--- a/src/views/oauth/OAuthStep.js
+++ b/src/views/oauth/OAuthStep.js
@@ -122,10 +122,7 @@ export const OAuthStep = React.forwardRef((props, navigationRef) => {
 
     let member$
 
-    // If there is already an existing member/current memeber, don't create a new one, use that one
-    if (member.is_oauth) {
-      member$ = of(member)
-    } else if (pendingOauthMember) {
+    if (pendingOauthMember) {
       // If there is a pending oauth member, don't create a new one, use that one
       member$ = of(pendingOauthMember)
     } else {

--- a/src/views/oauth/__tests__/OAuthStep-test.tsx
+++ b/src/views/oauth/__tests__/OAuthStep-test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { NEW_MEMBER } from 'src/services/mockedData'
 import { render, screen, waitFor } from 'src/utilities/testingLibrary'
 import { OAuthStep } from 'src/views/oauth/OAuthStep'
+import { apiValue } from 'src/const/apiProviderMock'
+import { ApiProvider } from 'src/context/ApiContext'
 
 describe('OauthStep view', () => {
   describe('Ensure OAuthDefault is rendered', () => {
@@ -11,11 +12,19 @@ describe('OauthStep view', () => {
     }
     it('should go back to Oauth Default when Try Again button is clicked on the waitingForOAuth screen', async () => {
       const ref = React.createRef()
-      const { user } = render(<OAuthStep {...defaultProps} ref={ref} />, {
-        preloadedState: {
-          connect: { members: [NEW_MEMBER], currentMemberGuid: NEW_MEMBER.guid },
+      const { user } = render(
+        <ApiProvider apiValue={apiValue}>
+          <OAuthStep {...defaultProps} ref={ref} />
+        </ApiProvider>,
+        {
+          preloadedState: {
+            connect: {
+              members: [],
+              currentMemberGuid: null,
+            },
+          },
         },
-      })
+      )
       const loginButton = await screen.findByTestId('continue-button')
 
       expect(loginButton).toBeInTheDocument()


### PR DESCRIPTION
Prevent OAuth from using a previously connected member, create a new one or use PENDING members instead.

It can cause accounts to combine into the wrong member record, yikes!