### PR TITLE
Jameson/CT-1171

### DIFF
--- a/src/hooks/useSelectInstitution.tsx
+++ b/src/hooks/useSelectInstitution.tsx
@@ -26,9 +26,15 @@ const useSelectInstitution = () => {
         map((institution) => {
           return selectInstitutionSuccess({ institution })
         }),
-        catchError((err) => of(selectInstitutionError(err))),
+        catchError((err) => {
+          setInstitutionGuid('')
+          return of(selectInstitutionError(err))
+        }),
       )
-      .subscribe((action) => dispatch(action))
+      .subscribe((action) => {
+        setInstitutionGuid('')
+        dispatch(action)
+      })
 
     return () => selectInstitution$.unsubscribe()
   }, [institutionGuid])


### PR DESCRIPTION
https://mxcom.atlassian.net/browse/CT-1171

#### Changes
- The select institution hook had a local state variable that needed to be cleared after hook runs.

#### Testing instructions
- Link to MXConnect and run all tests.
- Manual test:
  - Load Connect widget and click and institution.
  - Click back arrow in global nav and select same institution.
  - Ensure the widget continues to navigate correctly.
