### PR TITLE
Fix focus indicator around InstitutionTile

### DIFF
--- a/src/components/InstitutionTile.js
+++ b/src/components/InstitutionTile.js
@@ -35,6 +35,10 @@ export const InstitutionTile = (props) => {
         },
         '&:focus': {
           outline: `1px solid ${tokens.BorderColor.InputFocus}`,
+          // We offset the outline by a negative 1px so that
+          // It's placed exactly at the border edge of the element.
+          outlineOffset: '-1px',
+          boxShadow: 'none',
         },
         '&:active': {
           border: `1px solid ${tokens.BorderColor.InputFocus}`,
@@ -72,9 +76,6 @@ const getStyles = (tokens) => {
       boxSizing: 'border-box',
       alignItems: 'center',
       width: '100%',
-      // We provide a transparent border here to ensure our box sizing is the
-      // same with or without our focus border applied.
-      border: '1px solid transparent',
       zIndex: 1,
     },
     institutionBodyContainer: {


### PR DESCRIPTION
Issue: [https://mxcom.atlassian.net/browse/CT-1187](https://mxcom.atlassian.net/browse/CT-1187)

Replaced `border` with `outline` property for the focus indicator to work around the InstitutionTile.

### Testing instructions

- Load connect on a mobile web screen 
- On the search institution screen, type "mx" and ensure that you can tab through the list of searched institutions with the focus indicator showing.

![File (1)](https://github.com/user-attachments/assets/0eb99889-5957-47c6-ae0e-4d7ee8c32512)


