### PR TITLE
Add reconnected status to processing statuses

### DIFF
--- a/src/const/Statuses.js
+++ b/src/const/Statuses.js
@@ -48,6 +48,6 @@ export const ReadableStatuses = {
   PENDING: 21,
 }
 
-export const ProcessingStatuses = [0, 15, 18]
+export const ProcessingStatuses = [0, 8, 15, 18]
 export const MFAStatuses = [3, 4]
 export const ErrorStatuses = [1, 2, 3, 4, 5, 7, 9, 10, 11, 12, 13, 14, 16, 17, 19, 20]


### PR DESCRIPTION
Issue: [https://mxcom.atlassian.net/browse/CT-1181](https://mxcom.atlassian.net/browse/CT-1181)

This adds `RECONNECTED` member connection status  to the list of processing statuses which will allow the polling to happen and in turn results in an update to member status.

### Testing instructions

- Manually put a member into a `RECONNECTED` status in batcave.
- Load connect using `current_member_guid` set to the guid of the member above.
- Ensure that you are taken to the connecting step and that the member is eventually successfully connected.