### PR TITLE
Making verifyExistingMember header more descriptive

### DIFF
--- a/src/views/verification/VerifyExistingMember.tsx
+++ b/src/views/verification/VerifyExistingMember.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
 
@@ -10,6 +10,7 @@ import { InstitutionLogo } from '@kyper/institutionlogo'
 import { Button } from '@mui/material'
 
 import { __, _n } from 'src/utilities/Intl'
+import { focusElement } from 'src/utilities/Accessibility'
 
 import useAnalyticsPath from 'src/hooks/useAnalyticsPath'
 import { PageviewInfo } from 'src/const/Analytics'
@@ -27,6 +28,7 @@ interface VerifyExistingMemberProps {
 const VerifyExistingMember: React.FC<VerifyExistingMemberProps> = (props) => {
   useAnalyticsPath(...PageviewInfo.CONNECT_VERIFY_EXISTING_MEMBER)
   const { api } = useApi()
+  const searchForInstitution = useRef(null)
   const dispatch = useDispatch()
   const { members, onAddNew } = props
   const iavMembers = members.filter((member) => member.verification_is_enabled)
@@ -44,6 +46,10 @@ const VerifyExistingMember: React.FC<VerifyExistingMemberProps> = (props) => {
     setSelectedMember(selectedMember)
     setInstitution((state) => ({ ...state, isLoadingInstitution: true }))
   }
+
+  useEffect(() => {
+    focusElement(searchForInstitution.current)
+  }, [])
 
   useEffect(() => {
     if (!isLoadingInstitution || !selectedMember) return
@@ -85,6 +91,7 @@ const VerifyExistingMember: React.FC<VerifyExistingMemberProps> = (props) => {
         aria-label={__('Select your institution')}
         as="H2"
         data-test="verify-existing-member-header"
+        ref={searchForInstitution}
         style={styles.headerText}
         tabIndex={-1}
         tag={'h2'}
@@ -149,7 +156,6 @@ const getStyles = (tokens: any) => {
       flexDirection: 'column',
     } as React.CSSProperties,
     headerText: {
-      display: 'block',
       marginBottom: tokens.Spacing.Tiny,
     },
     primaryParagraph: {


### PR DESCRIPTION
Issue: [https://mxcom.atlassian.net/browse/CT-1175](https://mxcom.atlassian.net/browse/CT-1175)

### Changes

- Updated the header to be an H2 per Jen's guidance
- Made the header more descriptive for assistive technologies by allowing them to read it out when the page loads.

### Testing instructions
Load connect in verification mode and ensure that "Search your institution" header on VerifyExistingMember screen is an h2 and is read out when the page loads.