### PR TITLE
Fixed the color of the focus of the institution grid tile

### DIFF
--- a/src/components/InstitutionGridTile.js
+++ b/src/components/InstitutionGridTile.js
@@ -33,7 +33,7 @@ export const InstitutionGridTile = (props) => {
           boxShadow: '0px 0px 0px 4px rgba(238, 241, 246, 1)',
         },
         '&:focus .iconTile': {
-          boxShadow: '0px 0px 0px 4px rgba(228, 232, 238, 1)',
+          boxShadow: '0px 0px 0px 4px #2C64EF',
         },
         '&:focus': {
           boxShadow: 'none',


### PR DESCRIPTION
To test link to MX connect and on the institution search step make sure that the focus indicator is the same blue as the figma.  

Related issue: https://mxcom.atlassian.net/browse/CT-1318