### PR TITLE
Aw/ct 1417

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v.0.13.7
+
+### Fixed
+
+- Fixed accessibility issue with decorative image on shared routing number view
+
 ## v.0.13.6
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mxenabled/connect-widget",
   "description": "A simple ui library for React",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/src/components/InstitutionTile.js
+++ b/src/components/InstitutionTile.js
@@ -27,6 +27,7 @@ export const InstitutionTile = (props) => {
       onClick={selectInstitution}
       startIcon={
         <InstitutionLogo
+          alt=""
           institutionGuid={institution.guid}
           logoUrl={institution.logo_url}
           size={size}


### PR DESCRIPTION
#### Issue
https://mxcom.atlassian.net/browse/CT-1417

#### Changes
- Made the institution logo decorative so that screen readers ignore it.

#### Testing Instructions
- In connect in verification mode go to the shared routing number screen
-  Locate the "MX" image.
- Inspect it with Chrome DevTools.
- In the Accessibility tab, expand the Computed Properties section.
- Verify that the accessibility node is not exposed.