### PR TITLE
aw/CT-1394

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v.0.15.3
+
+### Fixed
+
+- Fixed accessibility issue on the request instituiton view with screen reader not breaking up sentences.
+
 ## v.0.15.2
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mxenabled/connect-widget",
   "description": "A simple ui library for React",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/src/components/support/RequestInstitution.js
+++ b/src/components/support/RequestInstitution.js
@@ -221,6 +221,7 @@ export const RequestInstitution = React.forwardRef((props, requestInstitutionRef
               {__('Continue')}
             </Button>
           </div>
+          <br />
           <PrivateAndSecure />
         </SlideDown>
 


### PR DESCRIPTION
#### Issue

https://mxcom.atlassian.net/browse/CT-1394

#### Changes 
used a <br> tag to separate the button and private and secure for screen readers

#### Testing instructions
- Open connect and go to the request institution page
- Use a screen reader and make sure that the button and private and secure text are read separately and not as the same sentence
- No harm testing  