### PR TITLE
Create a reference to the config values used to load the widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,51 @@
     }
   },
   "release": {
-    "branches": ["master"]
+    "branches": ["master"],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "releaseRules": [
+            {
+              "type": "build",
+              "release": "patch"
+            },
+            {
+              "type": "chore",
+              "release": "patch"
+            },
+            {
+              "type": "ci",
+              "release": "patch"
+            },
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "perf",
+              "release": "patch"
+            },
+            {
+              "type": "refactor",
+              "release": "patch"
+            },
+            {
+              "type": "revert",
+              "release": "patch"
+            },
+            {
+              "type": "style",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": "patch"
+            }
+          ]
+        }
+      ]
+    ]
   }
 }

--- a/src/redux/reducers/__tests__/config-test.js
+++ b/src/redux/reducers/__tests__/config-test.js
@@ -1,4 +1,8 @@
-import reducer, { initialState, selectUIMessageVersion } from 'src/redux/reducers/configSlice'
+import reducer, {
+  initialState,
+  selectInitialValues,
+  selectUIMessageVersion,
+} from 'src/redux/reducers/configSlice'
 import { loadConnect } from 'src/redux/actions/Connect'
 import { AGG_MODE, VERIFY_MODE } from 'src/const/Connect'
 import { COMBO_JOB_DATA_TYPES } from 'src/const/comboJobDataTypes'
@@ -144,5 +148,22 @@ describe('configSlice', () => {
     const uiMessageVersion = selectUIMessageVersion({ config: afterState })
 
     expect(uiMessageVersion).toBe(initialStateWithUiMessageVersion.ui_message_version)
+  })
+
+  it('should save the _initialValues used to load the widget and be able to retrieve them', () => {
+    const afterState = reducer(
+      initialState,
+      loadConnect({
+        ui_message_version: 4,
+        mode: VERIFY_MODE,
+      }),
+    )
+
+    const initialValues = selectInitialValues({ config: afterState })
+
+    // Remove _initialValues from the current state to compare the rest of the state
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { _initialValues, ...stateWithoutInitialValuesKey } = afterState
+    expect(initialValues).toEqual(stateWithoutInitialValuesKey)
   })
 })

--- a/typings/connectProps.d.ts
+++ b/typings/connectProps.d.ts
@@ -38,6 +38,7 @@ interface ConnectProps {
   userFeatures?: object
 }
 interface ClientConfigType {
+  _initialValues: string
   is_mobile_webview: boolean
   target_origin_referrer: string | null
   ui_message_protocol: string


### PR DESCRIPTION
This PR is in preparation for an upcoming feature that will dynamically change the widget's mode and a few other configurations.

Now when the config values change on the fly, there's a way to know how to get the widget back to how it was.