### PR TITLE
fix: fixes support success test

### DIFF
--- a/src/components/support/SupportSuccess.js
+++ b/src/components/support/SupportSuccess.js
@@ -15,7 +15,7 @@ import useAnalyticsPath from 'src/hooks/useAnalyticsPath'
 import { PageviewInfo } from 'src/const/Analytics'
 
 export const SupportSuccess = React.forwardRef((props, supportSuccessRef) => {
-  const { email, handleClose } = props
+  const { email, handleClose, setAriaLiveRegionMessage } = props
   useAnalyticsPath(...PageviewInfo.CONNECT_SUPPORT_SUCCESS)
   const tokens = useTokens()
   const styles = getStyles(tokens)
@@ -31,7 +31,7 @@ export const SupportSuccess = React.forwardRef((props, supportSuccessRef) => {
   const onClose = () => fadeOut(supportSuccessRef.current, 'up', 300).then(() => handleClose())
 
   useEffect(() => {
-    props.setAriaLiveRegionMessage(`${requestReceived} ${workingHours}`)
+    setAriaLiveRegionMessage(`${requestReceived} ${workingHours}`)
   }, [])
 
   return (


### PR DESCRIPTION
For some reason, the support success test is failing in [CI](https://github.com/mxenabled/connect-widget/actions/runs/15404660485/job/43478208277) but passes locally. I’m making a small change to how I access `setAriaLiveRegionMessage` prop to see if that resolves the issue.