### PR TITLE
Make  MFA OTP and verifyDeposits input fields visually required

### DIFF
--- a/src/components/RequiredFieldNote.tsx
+++ b/src/components/RequiredFieldNote.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Typography, Box } from '@mui/material'
+import { __ } from 'src/utilities/Intl'
+
+const RequiredFieldNote: React.FC = () => {
+  return (
+    <Box
+      sx={{
+        marginTop: 16,
+        marginBottom: 32,
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{
+          color: '#666',
+          fontSize: '13px',
+        }}
+        variant="caption"
+      >
+        <Typography
+          component="span"
+          sx={{
+            color: '#E32727',
+          }}
+        >
+          *
+        </Typography>{' '}
+        {__('Required')}
+      </Typography>
+    </Box>
+  )
+}
+
+export default RequiredFieldNote

--- a/src/components/RequiredFieldNote.tsx
+++ b/src/components/RequiredFieldNote.tsx
@@ -2,18 +2,27 @@ import React from 'react'
 import { Typography, Box } from '@mui/material'
 import { __ } from 'src/utilities/Intl'
 
-const RequiredFieldNote: React.FC = () => {
+interface RequiredFieldNoteProps {
+  styles?: object
+}
+
+const RequiredFieldNote: React.FC<RequiredFieldNoteProps> = ({ styles }) => {
+  // TODO: Replace with MXUI color tokens when available
+  const requiredFieldNoteColor = '#666'
+  const asteriskColor = '#E32727'
+
   return (
     <Box
       sx={{
         marginTop: 16,
         marginBottom: 32,
+        ...styles,
       }}
     >
       <Typography
         component="span"
         sx={{
-          color: '#666',
+          color: requiredFieldNoteColor,
           fontSize: '13px',
         }}
         variant="caption"
@@ -21,7 +30,7 @@ const RequiredFieldNote: React.FC = () => {
         <Typography
           component="span"
           sx={{
-            color: '#E32727',
+            color: asteriskColor,
           }}
         >
           *

--- a/src/components/support/GeneralSupport.js
+++ b/src/components/support/GeneralSupport.js
@@ -123,7 +123,7 @@ export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
             value={values.issueDescription}
           />
         </div>
-        <div style={styles.input}>
+        <div style={{ ...styles.input, marginBottom: 0 }}>
           <TextField
             autoComplete="off"
             disabled={submitting}

--- a/src/components/support/GeneralSupport.js
+++ b/src/components/support/GeneralSupport.js
@@ -19,6 +19,7 @@ import useAnalyticsPath from 'src/hooks/useAnalyticsPath'
 import { PageviewInfo } from 'src/const/Analytics'
 import { AriaLive } from 'src/components/AriaLive'
 import { useApi } from 'src/context/ApiContext'
+import RequiredFieldNote from 'src/components/RequiredFieldNote'
 
 export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
   const { handleClose, handleTicketSuccess, user } = props
@@ -101,6 +102,7 @@ export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
               label={schema.email.label}
               name="email"
               onChange={handleTextInputChange}
+              required={true}
               value={values.email}
             />
           </div>
@@ -117,6 +119,7 @@ export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
             label={schema.issueDescription.label}
             name="issueDescription"
             onChange={handleTextInputChange}
+            required={true}
             value={values.issueDescription}
           />
         </div>
@@ -132,11 +135,14 @@ export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
             multiline={true}
             name="issueDetails"
             onChange={handleTextInputChange}
+            required={true}
             rows={4}
             value={values.issueDetails}
           />
         </div>
       </SlideDown>
+
+      <RequiredFieldNote />
 
       <SlideDown delay={getNextDelay()}>
         <div style={styles.buttons}>

--- a/src/components/support/RequestInstitution.js
+++ b/src/components/support/RequestInstitution.js
@@ -19,6 +19,7 @@ import { useForm } from 'src/hooks/useForm'
 import useAnalyticsPath from 'src/hooks/useAnalyticsPath'
 import { PageviewInfo } from 'src/const/Analytics'
 import { useApi } from 'src/context/ApiContext'
+import RequiredFieldNote from 'src/components/RequiredFieldNote'
 
 export const RequestInstitution = React.forwardRef((props, requestInstitutionRef) => {
   const { handleClose, handleTicketSuccess, user } = props
@@ -134,6 +135,7 @@ export const RequestInstitution = React.forwardRef((props, requestInstitutionRef
                 label={schema.email.label}
                 name="email"
                 onChange={handleTextInputChange}
+                required={true}
                 value={values.email}
               />
             </div>
@@ -154,6 +156,7 @@ export const RequestInstitution = React.forwardRef((props, requestInstitutionRef
               label={schema.institutionName.label}
               name="institutionName"
               onChange={handleTextInputChange}
+              required={true}
               value={values.institutionName}
             />
           </div>
@@ -174,6 +177,7 @@ export const RequestInstitution = React.forwardRef((props, requestInstitutionRef
               label={schema.institutionWebsite.label}
               name="institutionWebsite"
               onChange={handleTextInputChange}
+              required={true}
               value={values.institutionWebsite}
             />
           </div>
@@ -197,7 +201,7 @@ export const RequestInstitution = React.forwardRef((props, requestInstitutionRef
             />
           </div>
         </SlideDown>
-
+        <RequiredFieldNote />
         <SlideDown delay={getNextDelay()}>
           <div style={styles.buttons}>
             <Button

--- a/src/components/support/RequestInstitution.js
+++ b/src/components/support/RequestInstitution.js
@@ -181,7 +181,7 @@ export const RequestInstitution = React.forwardRef((props, requestInstitutionRef
               value={values.institutionWebsite}
             />
           </div>
-          <div style={styles.input}>
+          <div style={{ ...styles.input, marginBottom: 0 }}>
             <TextField
               aria-label={schema.institutionLogin.label}
               autoComplete="off"

--- a/src/components/support/__tests__/GeneralSupport-test.tsx
+++ b/src/components/support/__tests__/GeneralSupport-test.tsx
@@ -22,9 +22,9 @@ describe('GeneralSupport', () => {
     const ref = React.createRef()
     const { user } = render(<GeneralSupport {...GeneralSupportProps} ref={ref} />)
 
-    await user.type(screen.getByLabelText('Your email address'), 'fake@fake.com')
-    await user.type(screen.getByLabelText('Brief description of the issue'), 'issues')
-    await user.type(screen.getByLabelText('Details of the issue'), 'lots of issues')
+    await user.type(screen.getByLabelText(/Your email address/i), 'fake@fake.com')
+    await user.type(screen.getByLabelText(/Brief description of the issue/i), 'issues')
+    await user.type(screen.getByLabelText(/Details of the issue/i), 'lots of issues')
     await user.click(screen.getByText('Continue'))
     await waitFor(() => {
       expect(handleTicketSuccess).toHaveBeenCalled()

--- a/src/components/support/__tests__/RequestInstitution-test.tsx
+++ b/src/components/support/__tests__/RequestInstitution-test.tsx
@@ -56,8 +56,8 @@ describe('RequestInstitution', () => {
     expect(await screen.findByText('Institution website is required')).toBeInTheDocument()
 
     // Type and submit values
-    await user.type(screen.getByLabelText('Institution name'), 'institution name')
-    await user.type(screen.getByLabelText('Institution website'), 'http://institution.name.com')
+    await user.type(screen.getByLabelText(/Institution name/i), 'institution name')
+    await user.type(screen.getByLabelText(/Institution website/i), 'http://institution.name.com')
     await user.click(continueButton)
 
     // // Handler should have now been called

--- a/src/components/support/__tests__/Support-test.tsx
+++ b/src/components/support/__tests__/Support-test.tsx
@@ -74,8 +74,8 @@ it('renders the success page after submitting a request via the menu', async () 
   expect(await screen.findByText('Institution website is required')).toBeInTheDocument()
 
   // Type and submit values
-  await userEvent.type(screen.getByLabelText('Institution name'), 'institution name')
-  await userEvent.type(screen.getByLabelText('Institution website'), 'http://institution.name.com')
+  await userEvent.type(screen.getByLabelText(/Institution name/i), 'institution name')
+  await userEvent.type(screen.getByLabelText(/Institution website/i), 'http://institution.name.com')
   await userEvent.click(continueButton)
 
   // Success page should render

--- a/src/views/mfa/DefaultMFA.js
+++ b/src/views/mfa/DefaultMFA.js
@@ -98,7 +98,7 @@ export const DefaultMFA = (props) => {
           </div>
         )
       })}
-      <RequiredFieldNote />
+      <RequiredFieldNote styles={{ marginTop: '-8px' }} />
       <Button
         data-test="continue-button"
         fullWidth={true}

--- a/src/views/mfa/DefaultMFA.js
+++ b/src/views/mfa/DefaultMFA.js
@@ -98,7 +98,7 @@ export const DefaultMFA = (props) => {
           </div>
         )
       })}
-      <RequiredFieldNote styles={{ marginTop: '-8px' }} />
+      <RequiredFieldNote />
       <Button
         data-test="continue-button"
         fullWidth={true}
@@ -123,7 +123,6 @@ const getStyles = (tokens) => {
   return {
     label: {
       marginTop: tokens.Spacing.XLarge,
-      marginBottom: tokens.Spacing.Large,
     },
     challengeLabel: {
       marginBottom: tokens.Spacing.Tiny,

--- a/src/views/mfa/DefaultMFA.js
+++ b/src/views/mfa/DefaultMFA.js
@@ -95,11 +95,10 @@ export const DefaultMFA = (props) => {
               required={true}
               value={values[credential.label] || ''}
             />
-            <RequiredFieldNote />
           </div>
         )
       })}
-
+      <RequiredFieldNote />
       <Button
         data-test="continue-button"
         fullWidth={true}

--- a/src/views/mfa/DefaultMFA.js
+++ b/src/views/mfa/DefaultMFA.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { sha256 } from 'js-sha256'
 
 import { useTokens } from '@kyper/tokenprovider'
-import { Text } from '@kyper/mui'
 import { TextField } from 'src/privacy/input'
 import { Button } from '@mui/material'
 
@@ -78,15 +77,6 @@ export const DefaultMFA = (props) => {
 
         return (
           <div key={credential.label} style={styles.label}>
-            <Text
-              component="p"
-              data-test="challenge-label"
-              style={styles.challengeLabel}
-              truncate={false}
-              variant="Paragraph"
-            >
-              {credential.label}
-            </Text>
             {metaData ? (
               <div style={styles.metaData}>
                 <img alt={__('Challenge Image')} src={metaData} style={styles.mfaImage} />
@@ -94,11 +84,12 @@ export const DefaultMFA = (props) => {
             ) : null}
             <TextField
               disabled={isSubmitting}
-              error={true}
+              error={!!errors[credential.label]}
               fullWidth={true}
               helperText={errors[credential.label]}
               inputProps={{ 'aria-label': credential.label }}
               inputRef={i === 0 ? buttonRef : null}
+              label={credential.label}
               name={credential.label}
               onChange={handleMFACodeChange}
               required={true}
@@ -113,7 +104,6 @@ export const DefaultMFA = (props) => {
         data-test="continue-button"
         fullWidth={true}
         onClick={handleSubmit}
-        style={styles.submitButton}
         type="submit"
         variant="contained"
       >
@@ -133,6 +123,7 @@ export const DefaultMFA = (props) => {
 const getStyles = (tokens) => {
   return {
     label: {
+      marginTop: tokens.Spacing.XLarge,
       marginBottom: tokens.Spacing.Large,
     },
     challengeLabel: {
@@ -151,9 +142,6 @@ const getStyles = (tokens) => {
       width: 'auto',
       height: 'auto',
       borderRadius: tokens.BorderRadius.Medium,
-    },
-    submitButton: {
-      marginTop: tokens.Spacing.XLarge,
     },
   }
 }

--- a/src/views/mfa/DefaultMFA.js
+++ b/src/views/mfa/DefaultMFA.js
@@ -17,6 +17,7 @@ import { useForm } from 'src/hooks/useForm'
 import { buildInitialValues, buildFormSchema } from 'src/views/mfa/utils'
 import { focusElement } from 'src/utilities/Accessibility'
 import { AriaLive } from 'src/components/AriaLive'
+import RequiredFieldNote from 'src/components/RequiredFieldNote'
 
 export const DefaultMFA = (props) => {
   const { currentMember, institution, isSubmitting, mfaCredentials, onSubmit } = props
@@ -100,8 +101,10 @@ export const DefaultMFA = (props) => {
               inputRef={i === 0 ? buttonRef : null}
               name={credential.label}
               onChange={handleMFACodeChange}
+              required={true}
               value={values[credential.label] || ''}
             />
+            <RequiredFieldNote />
           </div>
         )
       })}

--- a/src/views/microdeposits/PersonalInfoForm.js
+++ b/src/views/microdeposits/PersonalInfoForm.js
@@ -16,6 +16,7 @@ import { SlideDown } from 'src/components/SlideDown'
 import { useForm } from 'src/hooks/useForm'
 import { getDelay } from 'src/utilities/getDelay'
 import { fadeOut } from 'src/utilities/Animation'
+import RequiredFieldNote from 'src/components/RequiredFieldNote'
 
 export const PersonalInfoForm = ({ accountDetails, onContinue }) => {
   const containerRef = useRef(null)
@@ -127,11 +128,7 @@ export const PersonalInfoForm = ({ accountDetails, onContinue }) => {
             />
           </div>
         </SlideDown>
-        <div style={{ marginTop: 16, marginBottom: 32 }}>
-          <span style={{ color: '#666', fontSize: 13 }}>
-            <span style={{ color: '#E32727', fontSize: 13 }}>*</span> {__('Required')}
-          </span>
-        </div>
+        <RequiredFieldNote />
         <SlideDown delay={getNextDelay()}>
           <Button
             aria-label={__('Continue to account details')}

--- a/src/views/microdeposits/RoutingNumber.js
+++ b/src/views/microdeposits/RoutingNumber.js
@@ -28,6 +28,7 @@ import { useApi } from 'src/context/ApiContext'
 
 import { selectConnectConfig } from 'src/redux/reducers/configSlice'
 import { PostMessageContext } from 'src/ConnectWidget'
+import RequiredFieldNote from 'src/components/RequiredFieldNote'
 
 export const RoutingNumber = (props) => {
   const { accountDetails, onContinue, stepToIAV } = props
@@ -204,11 +205,7 @@ export const RoutingNumber = (props) => {
           </div>
         </SlideDown>
 
-        <div style={{ marginTop: 16, marginBottom: 32 }}>
-          <span style={{ color: '#666', fontSize: 13 }}>
-            <span style={{ color: '#E32727', fontSize: 13 }}>*</span> {__('Required')}
-          </span>
-        </div>
+        <RequiredFieldNote />
 
         <SlideDown delay={getNextDelay()}>
           <Button

--- a/src/views/microdeposits/VerifyDeposits.js
+++ b/src/views/microdeposits/VerifyDeposits.js
@@ -20,6 +20,7 @@ import { SlideDown } from 'src/components/SlideDown'
 import { MicrodepositsStatuses } from 'src/views/microdeposits/const'
 import { fadeOut } from 'src/utilities/Animation'
 import { useApi } from 'src/context/ApiContext'
+import RequiredFieldNote from 'src/components/RequiredFieldNote'
 
 const ACTIONS = {
   SET_SUBMITTING: 'verifyDeposits/set_submitting',
@@ -155,6 +156,7 @@ export const VerifyDeposits = ({ microdeposit, onSuccess }) => {
                 name="firstAmount"
                 onChange={handleTextInputChange}
                 placeholder="0.00"
+                required={true}
                 value={values.firstAmount}
               />
             </div>
@@ -174,12 +176,13 @@ export const VerifyDeposits = ({ microdeposit, onSuccess }) => {
                 name="secondAmount"
                 onChange={handleTextInputChange}
                 placeholder="0.00"
+                required={true}
                 value={values.secondAmount}
               />
             </div>
           </div>
         </SlideDown>
-
+        <RequiredFieldNote />
         <SlideDown>
           <Button
             data-test="continue-button"

--- a/src/views/microdeposits/VerifyDeposits.js
+++ b/src/views/microdeposits/VerifyDeposits.js
@@ -182,7 +182,7 @@ export const VerifyDeposits = ({ microdeposit, onSuccess }) => {
             </div>
           </div>
         </SlideDown>
-        <RequiredFieldNote />
+        <RequiredFieldNote styles={{ marginBottom: 0 }} />
         <SlideDown>
           <Button
             data-test="continue-button"


### PR DESCRIPTION
Issues: 

- [https://mxcom.atlassian.net/browse/CT-1505](https://mxcom.atlassian.net/browse/CT-1505)
-  [https://mxcom.atlassian.net/browse/CT-1506](https://mxcom.atlassian.net/browse/CT-1506)


### Changes

- Added `RequiredFieldNote` reusable component to indicate that items marked with * are required.
- Refactored our views to use it 

### Testing instructions

###  Verify Microdeposit

- Go through the Microdeposit flow up to the verifyDeposits screen
- Ensure the star (*) character is in the field label
- Ensure `* Required` note is shown below the text inputs

![Screenshot 2025-06-16 at 15 12 14](https://github.com/user-attachments/assets/245d53b2-8942-477e-bb10-66d6016419d1)

### MFA OTP input

- Load connect and select Gringotts
- Enter your username and `options` as password
- From the MFA options list, select `challenge`
- Ensure the star (*) character is in the field label
- Ensure `* Required` note is shown below the text inputs

![Screenshot 2025-06-17 at 11 40 07](https://github.com/user-attachments/assets/bcf1e9f7-1a22-42f5-830f-f2fc940ee3b2)



