### PR TITLE
Make general support request input fields visually required

### DIFF
--- a/src/components/support/GeneralSupport.js
+++ b/src/components/support/GeneralSupport.js
@@ -19,6 +19,7 @@ import useAnalyticsPath from 'src/hooks/useAnalyticsPath'
 import { PageviewInfo } from 'src/const/Analytics'
 import { AriaLive } from 'src/components/AriaLive'
 import { useApi } from 'src/context/ApiContext'
+import RequiredFieldNote from 'src/components/RequiredFieldNote'
 
 export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
   const { handleClose, handleTicketSuccess, user } = props
@@ -101,6 +102,7 @@ export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
               label={schema.email.label}
               name="email"
               onChange={handleTextInputChange}
+              required={true}
               value={values.email}
             />
           </div>
@@ -117,6 +119,7 @@ export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
             label={schema.issueDescription.label}
             name="issueDescription"
             onChange={handleTextInputChange}
+            required={true}
             value={values.issueDescription}
           />
         </div>
@@ -132,11 +135,14 @@ export const GeneralSupport = React.forwardRef((props, generalSupportRef) => {
             multiline={true}
             name="issueDetails"
             onChange={handleTextInputChange}
+            required={true}
             rows={4}
             value={values.issueDetails}
           />
         </div>
       </SlideDown>
+
+      <RequiredFieldNote />
 
       <SlideDown delay={getNextDelay()}>
         <div style={styles.buttons}>

--- a/src/components/support/__tests__/GeneralSupport-test.tsx
+++ b/src/components/support/__tests__/GeneralSupport-test.tsx
@@ -22,9 +22,9 @@ describe('GeneralSupport', () => {
     const ref = React.createRef()
     const { user } = render(<GeneralSupport {...GeneralSupportProps} ref={ref} />)
 
-    await user.type(screen.getByLabelText('Your email address'), 'fake@fake.com')
-    await user.type(screen.getByLabelText('Brief description of the issue'), 'issues')
-    await user.type(screen.getByLabelText('Details of the issue'), 'lots of issues')
+    await user.type(screen.getByLabelText(/Your email address/i), 'fake@fake.com')
+    await user.type(screen.getByLabelText(/Brief description of the issue/i), 'issues')
+    await user.type(screen.getByLabelText(/Details of the issue/i), 'lots of issues')
     await user.click(screen.getByText('Continue'))
     await waitFor(() => {
       expect(handleTicketSuccess).toHaveBeenCalled()


### PR DESCRIPTION
Issue: [https://mxcom.atlassian.net/browse/CT-1508](https://mxcom.atlassian.net/browse/CT-1508)

### Testing instructions

- Load connect and trigger the general support request screen
- Ensure the star (*) character is in the field label
- Ensure * Required note is shown below the text inputs

![Screenshot 2025-06-17 at 13 02 18](https://github.com/user-attachments/assets/f5cae1dd-1b28-4771-89a4-e538cb8a4378)
