### PR TITLE
CT-1651 | Add customizable text to the additional product page

### DIFF
--- a/src/ConnectWidget.tsx
+++ b/src/ConnectWidget.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { createContext } from 'react'
+import React, { createContext, useEffect } from 'react'
 import { Provider } from 'react-redux'
 
 import Store from 'src/redux/Store'
@@ -8,6 +8,7 @@ import { WidgetDimensionObserver } from 'src/components/app/WidgetDimensionObser
 import { initGettextLocaleData } from 'src/utilities/Personalization'
 import { ConnectedTokenProvider } from 'src/ConnectedTokenProvider'
 import { TooSmallDialog } from 'src/components/app/TooSmallDialog'
+import { setLocalizedContent } from 'src/redux/reducers/localizedContentSlice'
 
 interface PostMessageContextType {
   postMessageEventOverrides?: PostMessageEventOverrides
@@ -15,6 +16,10 @@ interface PostMessageContextType {
 }
 
 export const PostMessageContext = createContext<PostMessageContextType>({ onPostMessage: () => {} })
+
+function setupLocalizedContent(localizedContent: Record<string, any>) {
+  Store.dispatch(setLocalizedContent(localizedContent))
+}
 
 export const ConnectWidget = ({
   onPostMessage = () => {},
@@ -24,6 +29,11 @@ export const ConnectWidget = ({
   ...props
 }: any) => {
   initGettextLocaleData(props.language)
+
+  useEffect(() => {
+    setupLocalizedContent(props?.language?.localizedContent || {})
+  }, [])
+
   return (
     <Provider store={Store}>
       <ConnectedTokenProvider>

--- a/src/redux/Store.ts
+++ b/src/redux/Store.ts
@@ -6,6 +6,7 @@ import userFeaturesSlice from 'src/redux/reducers/userFeaturesSlice'
 import { app } from 'src/redux/reducers/App'
 import browser from 'src/redux/reducers/Browser'
 import analyticsSlice from 'src/redux/reducers/analyticsSlice'
+import localizedContentSlice from './reducers/localizedContentSlice'
 
 const rootReducer = combineReducers({
   analytics: analyticsSlice,
@@ -13,6 +14,7 @@ const rootReducer = combineReducers({
   browser,
   config: configSlice,
   connect,
+  localizedContent: localizedContentSlice,
   profiles: profilesSlice,
   userFeatures: userFeaturesSlice,
 })

--- a/src/redux/__tests__/Store-test.js
+++ b/src/redux/__tests__/Store-test.js
@@ -16,6 +16,7 @@ describe('Store', () => {
       'browser',
       'config',
       'connect',
+      'localizedContent',
       'profiles',
       'userFeatures',
     ]

--- a/src/redux/reducers/localizedContentSlice.ts
+++ b/src/redux/reducers/localizedContentSlice.ts
@@ -1,0 +1,40 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { RootState } from 'src/redux/Store'
+import { createSelector } from '@reduxjs/toolkit'
+
+type AdditionalProductScreenText = {
+  title?: string
+  body?: string
+  button_1?: string
+  button_2?: string
+}
+
+type LocalizedContent = {
+  connect?: {
+    additional_product_screen?: {
+      add_aggregation?: AdditionalProductScreenText
+      add_verification?: AdditionalProductScreenText
+    }
+  }
+}
+
+const initialState: LocalizedContent = {}
+
+const localizedContentSlice = createSlice({
+  name: 'localizedContent',
+  initialState,
+  reducers: {
+    setLocalizedContent(_state, action: PayloadAction<LocalizedContent>) {
+      return action.payload
+    },
+  },
+})
+
+export const { setLocalizedContent } = localizedContentSlice.actions
+
+export default localizedContentSlice.reducer
+
+export const selectLocalizedContent = createSelector(
+  (state: RootState) => state.localizedContent,
+  (localizedContent) => localizedContent,
+)

--- a/src/views/additionalProduct/AdditionalProductStep.tsx
+++ b/src/views/additionalProduct/AdditionalProductStep.tsx
@@ -8,6 +8,7 @@ import { __ } from 'src/utilities/Intl'
 import { COMBO_JOB_DATA_TYPES } from 'src/const/comboJobDataTypes'
 import { SlideDown } from 'src/components/SlideDown'
 import { getDelay } from 'src/utilities/getDelay'
+import { selectLocalizedContent } from 'src/redux/reducers/localizedContentSlice'
 
 type AdditionalProductStepText = {
   title: string
@@ -43,6 +44,8 @@ const AdditionalProductStep = React.forwardRef(
     navigationRef,
   ) => {
     const selectedInstitution = useSelector(getSelectedInstitution)
+    const { add_aggregation = {}, add_verification = {} } =
+      useSelector(selectLocalizedContent)?.connect?.additional_product_screen || {}
 
     useImperativeHandle(navigationRef, () => {
       return {
@@ -54,22 +57,28 @@ const AdditionalProductStep = React.forwardRef(
 
     const getNextDelay = getDelay()
 
+    // Apply customizable text for adding aggregation, if provided
     const addAggregationText: AdditionalProductStepText = {
-      title: __('Add financial management?'),
-      body: __(
-        "You're connecting this account for payments and transfers. Would you like to also enable financial management so you can track your income and spending?",
-      ),
-      acceptButtonText: __('Yes, add financial management'),
-      rejectButtonText: __('No, only add transfers and payments'),
+      title: add_aggregation?.title || __('Add financial management?'),
+      body:
+        add_aggregation?.body ||
+        __(
+          "You're connecting this account for payments and transfers. Would you like to also enable financial management so you can track your income and spending?",
+        ),
+      acceptButtonText: add_aggregation?.button_1 || __('Yes, add financial management'),
+      rejectButtonText: add_aggregation?.button_2 || __('No, only add transfers and payments'),
     }
 
+    // Apply customizable text for adding verification, if provided
     const addVerificationText: AdditionalProductStepText = {
-      title: __('Add transfers and payments?'),
-      body: __(
-        "You're connecting this account for financial management. Would you like to also enable transfers and payments so you can quickly move money to and from this institution?",
-      ),
-      acceptButtonText: __('Yes, add transfers and payments'),
-      rejectButtonText: __('No, only add financial management'),
+      title: add_verification?.title || __('Add transfers and payments?'),
+      body:
+        add_verification?.body ||
+        __(
+          "You're connecting this account for financial management. Would you like to also enable transfers and payments so you can quickly move money to and from this institution?",
+        ),
+      acceptButtonText: add_verification?.button_1 || __('Yes, add transfers and payments'),
+      rejectButtonText: add_verification?.button_2 || __('No, only add financial management'),
     }
 
     const componentText =


### PR DESCRIPTION
MX Internal - see https://mxcom.atlassian.net/browse/CT-1651 for more details

The Connect Widget can now support custom text for the Additional Product Page.  To customize it, pass the following structure with your custom strings into `props.language.localizedContent` when you load the ConnectWidget component.

```json
{
  "connect": {
    "additional_product_screen": {
      "add_aggregation": {
        "body": "",
        "title": "",
        "button_1": "",
        "button_2": ""
      },
      "add_verification": {
        "body": "",
        "title": "",
        "button_1": "",
        "button_2": ""
      }
    }
  }
}
```

Ex:
```js
<ConnectWidget
    ...
    language={{
      locale: 'en',
      custom_copy_namespace: '',
      localizedContent, // <<<< Pass the structure here
    }}
    ...
>
   {props.children}
</ConnectWidget>
```