### PR TITLE
feat: add header override

### DIFF
--- a/src/ConnectWidget.tsx
+++ b/src/ConnectWidget.tsx
@@ -15,7 +15,12 @@ interface PostMessageContextType {
   onPostMessage: (event: string, data?: object) => void
 }
 
+interface ConnectOverridesContextType {
+  aggregatorHeaderOverride?: string
+}
+
 export const PostMessageContext = createContext<PostMessageContextType>({ onPostMessage: () => {} })
+export const ConnectOverridesContext = createContext<ConnectOverridesContextType>({})
 
 function setupLocalizedContent(localizedContent: Record<string, any>) {
   Store.dispatch(setLocalizedContent(localizedContent))
@@ -26,6 +31,7 @@ export const ConnectWidget = ({
   onAnalyticPageview = () => {},
   postMessageEventOverrides,
   showTooSmallDialog = true,
+  aggregatorHeaderOverride,
   ...props
 }: any) => {
   initGettextLocaleData(props.language)
@@ -38,10 +44,12 @@ export const ConnectWidget = ({
     <Provider store={Store}>
       <ConnectedTokenProvider>
         <PostMessageContext.Provider value={{ onPostMessage, postMessageEventOverrides }}>
-          <WidgetDimensionObserver heightOffset={0}>
-            {showTooSmallDialog && <TooSmallDialog onAnalyticPageview={onAnalyticPageview} />}
-            <Connect onAnalyticPageview={onAnalyticPageview} {...props} />
-          </WidgetDimensionObserver>
+          <ConnectOverridesContext.Provider value={{ aggregatorHeaderOverride }}>
+            <WidgetDimensionObserver heightOffset={0}>
+              {showTooSmallDialog && <TooSmallDialog onAnalyticPageview={onAnalyticPageview} />}
+              <Connect onAnalyticPageview={onAnalyticPageview} {...props} />
+            </WidgetDimensionObserver>
+          </ConnectOverridesContext.Provider>
         </PostMessageContext.Provider>
       </ConnectedTokenProvider>
     </Provider>

--- a/src/ConnectWidget.tsx
+++ b/src/ConnectWidget.tsx
@@ -15,12 +15,7 @@ interface PostMessageContextType {
   onPostMessage: (event: string, data?: object) => void
 }
 
-interface ConnectOverridesContextType {
-  aggregatorHeaderOverride?: string
-}
-
 export const PostMessageContext = createContext<PostMessageContextType>({ onPostMessage: () => {} })
-export const ConnectOverridesContext = createContext<ConnectOverridesContextType>({})
 
 function setupLocalizedContent(localizedContent: Record<string, any>) {
   Store.dispatch(setLocalizedContent(localizedContent))
@@ -31,7 +26,6 @@ export const ConnectWidget = ({
   onAnalyticPageview = () => {},
   postMessageEventOverrides,
   showTooSmallDialog = true,
-  aggregatorHeaderOverride,
   ...props
 }: any) => {
   initGettextLocaleData(props.language)
@@ -44,12 +38,10 @@ export const ConnectWidget = ({
     <Provider store={Store}>
       <ConnectedTokenProvider>
         <PostMessageContext.Provider value={{ onPostMessage, postMessageEventOverrides }}>
-          <ConnectOverridesContext.Provider value={{ aggregatorHeaderOverride }}>
-            <WidgetDimensionObserver heightOffset={0}>
-              {showTooSmallDialog && <TooSmallDialog onAnalyticPageview={onAnalyticPageview} />}
-              <Connect onAnalyticPageview={onAnalyticPageview} {...props} />
-            </WidgetDimensionObserver>
-          </ConnectOverridesContext.Provider>
+          <WidgetDimensionObserver heightOffset={0}>
+            {showTooSmallDialog && <TooSmallDialog onAnalyticPageview={onAnalyticPageview} />}
+            <Connect onAnalyticPageview={onAnalyticPageview} {...props} />
+          </WidgetDimensionObserver>
         </PostMessageContext.Provider>
       </ConnectedTokenProvider>
     </Provider>

--- a/src/components/ConnectLogoHeader.tsx
+++ b/src/components/ConnectLogoHeader.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React from 'react'
+import React, { useContext } from 'react'
 import { useSelector } from 'react-redux'
 import { InstitutionLogo } from '@kyper/mui'
 import { useTokens } from '@kyper/tokenprovider'
@@ -15,6 +15,7 @@ import ConnectHeaderInstitutionDark from 'src/images/header/ConnectHeaderInstitu
 
 import ConnectHeaderBackdropDark from 'src/images/header/ConnectHeaderBackdropDark.svg'
 import ConnectHeaderBackdropLight from 'src/images/header/ConnectHeaderBackdropLight.svg'
+import { ConnectOverridesContext } from 'src/ConnectWidget'
 
 interface ConnectLogoHeaderProps {
   institutionGuid?: string
@@ -22,6 +23,8 @@ interface ConnectLogoHeaderProps {
 }
 
 export const ConnectLogoHeader: React.FC<ConnectLogoHeaderProps> = (props) => {
+  const { aggregatorHeaderOverride } = useContext(ConnectOverridesContext)
+
   const colorScheme = useSelector(selectColorScheme)
   const clientGuid = useSelector((state: any) => state.profiles.client.guid)
   const tokens = useTokens()
@@ -37,13 +40,20 @@ export const ConnectLogoHeader: React.FC<ConnectLogoHeaderProps> = (props) => {
       </div>
     )
 
+  const aggregatorLogo = () =>
+    colorScheme === COLOR_SCHEME.LIGHT ? (
+      <ConnectHeaderBackdropLight />
+    ) : (
+      <ConnectHeaderBackdropDark />
+    )
+
   return (
     <div aria-hidden={true} style={styles.container}>
       <div data-test="mxLogo" style={styles.backdropImage}>
-        {colorScheme === COLOR_SCHEME.LIGHT ? (
-          <ConnectHeaderBackdropLight />
+        {aggregatorHeaderOverride ? (
+          <img alt="aggregator logo" height={64} src={aggregatorHeaderOverride} width={64} />
         ) : (
-          <ConnectHeaderBackdropDark />
+          aggregatorLogo()
         )}
       </div>
       <div style={styles.clientLogo}>

--- a/src/components/ConnectLogoHeader.tsx
+++ b/src/components/ConnectLogoHeader.tsx
@@ -40,7 +40,7 @@ export const ConnectLogoHeader: React.FC<ConnectLogoHeaderProps> = (props) => {
       </div>
     )
 
-  const aggregatorLogo = () =>
+  const defaultAggregatorLogo = () =>
     colorScheme === COLOR_SCHEME.LIGHT ? (
       <ConnectHeaderBackdropLight />
     ) : (
@@ -56,7 +56,7 @@ export const ConnectLogoHeader: React.FC<ConnectLogoHeaderProps> = (props) => {
             style={styles.aggregatorLogo}
           />
         ) : (
-          aggregatorLogo()
+          defaultAggregatorLogo()
         )}
       </div>
       <div style={styles.clientLogo}>
@@ -118,6 +118,7 @@ const getStyles = () => {
       width: '88px',
       height: '80px',
       zIndex: 10,
-    },
+      position: 'relative',
+    } as React.CSSProperties,
   }
 }

--- a/src/components/ConnectLogoHeader.tsx
+++ b/src/components/ConnectLogoHeader.tsx
@@ -51,7 +51,7 @@ export const ConnectLogoHeader: React.FC<ConnectLogoHeaderProps> = (props) => {
     <div aria-hidden={true} style={styles.container}>
       <div data-test="mxLogo" style={styles.backdropImage}>
         {aggregatorHeaderOverride ? (
-          <img alt="aggregator logo" height={64} src={aggregatorHeaderOverride} width={64} />
+          <img alt="aggregator logo" src={aggregatorHeaderOverride} style={styles.aggregatorLogo} />
         ) : (
           aggregatorLogo()
         )}
@@ -110,6 +110,11 @@ const getStyles = () => {
       width: maxHeight,
       marginLeft: '80px',
       zIndex: 20,
+    },
+    aggregatorLogo: {
+      width: '88px',
+      height: '80px',
+      zIndex: 10,
     },
   }
 }

--- a/src/components/ConnectLogoHeader.tsx
+++ b/src/components/ConnectLogoHeader.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useContext } from 'react'
+import React from 'react'
 import { useSelector } from 'react-redux'
 import { InstitutionLogo } from '@kyper/mui'
 import { useTokens } from '@kyper/tokenprovider'
@@ -15,16 +15,16 @@ import ConnectHeaderInstitutionDark from 'src/images/header/ConnectHeaderInstitu
 
 import ConnectHeaderBackdropDark from 'src/images/header/ConnectHeaderBackdropDark.svg'
 import ConnectHeaderBackdropLight from 'src/images/header/ConnectHeaderBackdropLight.svg'
-import { ConnectOverridesContext } from 'src/ConnectWidget'
 
 interface ConnectLogoHeaderProps {
-  institutionGuid?: string
-  institutionLogo?: string
+  institution?: {
+    guid?: string
+    logo_url?: string
+    aggregator_logo_url?: string
+  }
 }
 
 export const ConnectLogoHeader: React.FC<ConnectLogoHeaderProps> = (props) => {
-  const { aggregatorHeaderOverride } = useContext(ConnectOverridesContext)
-
   const colorScheme = useSelector(selectColorScheme)
   const clientGuid = useSelector((state: any) => state.profiles.client.guid)
   const tokens = useTokens()
@@ -46,12 +46,15 @@ export const ConnectLogoHeader: React.FC<ConnectLogoHeaderProps> = (props) => {
     ) : (
       <ConnectHeaderBackdropDark />
     )
-
   return (
     <div aria-hidden={true} style={styles.container}>
       <div data-test="mxLogo" style={styles.backdropImage}>
-        {aggregatorHeaderOverride ? (
-          <img alt="aggregator logo" src={aggregatorHeaderOverride} style={styles.aggregatorLogo} />
+        {props?.institution?.aggregator_logo_url ? (
+          <img
+            alt="aggregator logo"
+            src={props.institution.aggregator_logo_url}
+            style={styles.aggregatorLogo}
+          />
         ) : (
           aggregatorLogo()
         )}
@@ -60,11 +63,11 @@ export const ConnectLogoHeader: React.FC<ConnectLogoHeaderProps> = (props) => {
         <ClientLogo alt="Client logo" clientGuid={clientGuid} size={64} />
       </div>
       <div style={styles.institutionLogo}>
-        {props.institutionGuid ? (
+        {props?.institution?.guid ? (
           <InstitutionLogo
             alt="Institution logo"
-            institutionGuid={props.institutionGuid}
-            logoUrl={props.institutionLogo}
+            institutionGuid={props.institution.guid}
+            logoUrl={props.institution.logo_url}
             size={64}
             style={{ borderRadius: tokens.BorderRadius.Large }}
           />

--- a/src/components/__tests__/ConnectLogoHeader-test.tsx
+++ b/src/components/__tests__/ConnectLogoHeader-test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render, screen } from 'src/utilities/testingLibrary'
 import { ConnectLogoHeader } from 'src/components/ConnectLogoHeader'
-import { ConnectOverridesContext } from 'src/ConnectWidget'
 
 describe('ConnectLogoHeader', () => {
   const clientGuid = 'CLT-123'
@@ -44,7 +43,7 @@ describe('ConnectLogoHeader', () => {
   it('renders a custom logoUrl if an institutionGuid and institutionLogo was passed in props', () => {
     const logoUrl = 'testUrl'
 
-    render(<ConnectLogoHeader institutionGuid="INS-123" institutionLogo={logoUrl} />, {
+    render(<ConnectLogoHeader institution={{ guid: 'INS-123', logo_url: logoUrl }} />, {
       preloadedState: initialState,
     })
 
@@ -54,7 +53,7 @@ describe('ConnectLogoHeader', () => {
 
   it('renders an InstitutionLogo if an institutionGuid was passed in props', () => {
     const institutionGuid = 'INS-123'
-    render(<ConnectLogoHeader institutionGuid={institutionGuid} />, {
+    render(<ConnectLogoHeader institution={{ guid: institutionGuid }} />, {
       preloadedState: initialState,
     })
 
@@ -72,12 +71,7 @@ describe('ConnectLogoHeader', () => {
   it('renders the aggregatorHeaderOverride when provided', () => {
     const overrideUrl = 'https://example.com/logo.png'
 
-    render(
-      <ConnectOverridesContext.Provider value={{ aggregatorHeaderOverride: overrideUrl }}>
-        <ConnectLogoHeader />
-      </ConnectOverridesContext.Provider>,
-      { preloadedState: initialState },
-    )
+    render(<ConnectLogoHeader institution={{ aggregator_logo_url: overrideUrl }} />)
 
     const img = screen.getByAltText('aggregator logo')
     expect(img.getAttribute('src')).toEqual(overrideUrl)

--- a/src/components/__tests__/ConnectLogoHeader-test.tsx
+++ b/src/components/__tests__/ConnectLogoHeader-test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render, screen } from 'src/utilities/testingLibrary'
 import { ConnectLogoHeader } from 'src/components/ConnectLogoHeader'
+import { ConnectOverridesContext } from 'src/ConnectWidget'
 
 describe('ConnectLogoHeader', () => {
   const clientGuid = 'CLT-123'
@@ -66,5 +67,19 @@ describe('ConnectLogoHeader', () => {
   it('renders two SVGImage if an institutionGuid is not passed in props', () => {
     render(<ConnectLogoHeader />, { preloadedState: initialState })
     expect(screen.queryAllByTestId('svg-image').length).toBe(2)
+  })
+
+  it('renders the aggregatorHeaderOverride when provided', () => {
+    const overrideUrl = 'https://example.com/logo.png'
+
+    render(
+      <ConnectOverridesContext.Provider value={{ aggregatorHeaderOverride: overrideUrl }}>
+        <ConnectLogoHeader />
+      </ConnectOverridesContext.Provider>,
+      { preloadedState: initialState },
+    )
+
+    const img = screen.getByAltText('aggregator logo')
+    expect(img.getAttribute('src')).toEqual(overrideUrl)
   })
 })

--- a/src/views/connecting/Connecting.js
+++ b/src/views/connecting/Connecting.js
@@ -329,10 +329,7 @@ export const Connecting = (props) => {
     <div ref={connectingRef} style={styles.container}>
       <SlideDown delay={getNextDelay()}>
         <div style={styles.logoHeader}>
-          <ConnectLogoHeader
-            institutionGuid={institution.guid}
-            institutionLogo={institution.logo_url}
-          />
+          <ConnectLogoHeader institution={institution} />
         </div>
         <Text component="h2" style={styles.subHeader} truncate={false} variant="H2">
           {__('Connecting to %1', institution.name)}

--- a/src/views/consent/DynamicDisclosure.tsx
+++ b/src/views/consent/DynamicDisclosure.tsx
@@ -152,7 +152,7 @@ export const DynamicDisclosure = React.forwardRef<any, DynamicDisclosureProps>(
         <Fragment>
           <SlideDown delay={getNextDelay()}>
             <div style={styles.logoHeader}>
-              <ConnectLogoHeader institutionGuid={institution.guid} />
+              <ConnectLogoHeader institution={institution} />
             </div>
           </SlideDown>
           <SlideDown delay={getNextDelay()}>

--- a/src/views/disclosure/Interstitial.js
+++ b/src/views/disclosure/Interstitial.js
@@ -71,7 +71,7 @@ export const DisclosureInterstitial = React.forwardRef((props, interstitialNavRe
     <Fragment>
       <SlideDown delay={getNextDelay()}>
         <div style={styles.logoHeader}>
-          <ConnectLogoHeader institutionGuid={institution.guid} />
+          <ConnectLogoHeader institution={institution} />
         </div>
       </SlideDown>
       <SlideDown delay={getNextDelay()}>


### PR DESCRIPTION
Testing Instructions: connect an account and make sure the header looks the same as before. 

Here is an example of what it could look like with the sophtron logo: 
<img width="492" height="359" alt="Screenshot 2025-07-30 at 5 08 27 PM" src="https://github.com/user-attachments/assets/1023ff35-8c25-4de4-831c-bd3327c694e5" />
