### PR TITLE
refactor(search): added CSS modules support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ npm install @mxenabled/connect-widget
 ## Usage
 
 1. Install package: `npm install --save @mxenabled/connect-widget`
-2. Import `ApiProvider` and `ConnectWidget`. Add both to your project.
-3. Pass applicable props to widget and your API to the provider.
+1. Import the styles `import "@mxenabled/connect-widget/dist/style.css"`
+1. Import `ApiProvider` and `ConnectWidget`. Add both to your project.
+1. Pass applicable props to widget and your API to the provider.
 
 ```jsx
 import ConnectWidget, { ApiProvider } from '@mxenabled/connect-widget'

--- a/src/views/search/Search.js
+++ b/src/views/search/Search.js
@@ -42,6 +42,7 @@ import { useApi } from 'src/context/ApiContext'
 import { SEARCH_PAGE_DEFAULT, SEARCH_PER_PAGE_DEFAULT } from 'src/views/search/consts'
 import { COMBO_JOB_DATA_TYPES } from 'src/const/comboJobDataTypes'
 import { PostMessageContext } from 'src/ConnectWidget'
+import styles from './search.module.css'
 
 export const initialState = {
   currentView: SEARCH_VIEWS.LOADING,
@@ -315,7 +316,7 @@ export const Search = React.forwardRef((props, navigationRef) => {
   }, 500)
 
   const tokens = useTokens()
-  const styles = getStyles(tokens, state.currentView)
+  const inlineStyles = getStyles(tokens, state.currentView)
 
   // This allows us to bubble up the exception in the case of an endpoint failing
   // Which will show the GlobalErrorBoundary screen, while retaining the error
@@ -334,15 +335,15 @@ export const Search = React.forwardRef((props, navigationRef) => {
   }
 
   return (
-    <div style={styles.container}>
-      <div style={styles.searchBar}>
+    <div className={styles.container}>
+      <div style={inlineStyles.searchBar}>
         <Text
           aria-label={__('Select your institution')}
           bold={true}
           component={'h2'}
           data-test="search-header"
           id="connect-search-header"
-          style={styles.headerText}
+          style={inlineStyles.headerText}
           tabIndex={-1}
           truncate={false}
           variant="H2"
@@ -371,7 +372,7 @@ export const Search = React.forwardRef((props, navigationRef) => {
                     searchInput.current.value = '' // Thinking about changing this to a controlled component to manage the value
                     searchInput.current.focus()
                   }}
-                  style={styles.resetButton}
+                  style={inlineStyles.resetButton}
                   variant="text"
                 >
                   <CloseOutline />
@@ -393,7 +394,7 @@ export const Search = React.forwardRef((props, navigationRef) => {
         />
       </div>
       {state.currentView === SEARCH_VIEWS.LOADING && (
-        <div style={styles.spinner}>
+        <div style={inlineStyles.spinner}>
           <LoadingSpinner />
         </div>
       )}
@@ -413,7 +414,7 @@ export const Search = React.forwardRef((props, navigationRef) => {
         />
       )}
       {state.currentView === SEARCH_VIEWS.SEARCH_LOADING && (
-        <div style={styles.spinner}>
+        <div style={inlineStyles.spinner}>
           <LoadingSpinner />
         </div>
       )}

--- a/src/views/search/search.module.css
+++ b/src/views/search/search.module.css
@@ -1,0 +1,5 @@
+.container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
Added CSS modules support with example usage and readme improvements

BREAKING CHANGE: Consumers of the package need to import the package's style file