### PR TITLE
Always go back to search when navigating back from credentials

### DIFF
--- a/src/Connect.tsx
+++ b/src/Connect.tsx
@@ -270,8 +270,6 @@ export const Connect: React.FC<ConnectProps> = ({
     if (state.returnToMicrodeposits) {
       dispatch(connectActions.stepToMicrodeposits())
       setState({ ...state, returnToMicrodeposits: false })
-    } else if (consentIsEnabled || connectConfig.additional_product_option) {
-      dispatch(handleGoBackWithSideEffects())
     } else {
       postMessageFunctions.onPostMessage(POST_MESSAGES.BACK_TO_SEARCH, {})
 

--- a/src/redux/reducers/Connect.js
+++ b/src/redux/reducers/Connect.js
@@ -104,6 +104,24 @@ const goBackSearchOrVerify = (state, { payload }) => {
   }
 }
 
+/**
+ * Resets the widget to the search step when a user navigates back from the credentials screen.
+ * This prevents users from getting stuck in a loop when they enter incorrect credentials multiple times.
+ */
+const goBackCredentials = (state) => {
+  return {
+    ...state,
+    location: [{ step: STEPS.SEARCH }],
+    currentMemberGuid: defaultState.currentMemberGuid,
+    error: defaultState.error,
+    updateCredentials: defaultState.updateCredentials,
+    oauthURL: defaultState.oauthURL,
+    oauthErrorReason: defaultState.oauthErrorReason,
+    jobSchedule: JobSchedule.UNINITIALIZED,
+    selectedInstitution: defaultState.selectedInstitution,
+  }
+}
+
 const resetWidgetMFAStep = (state, { payload }) => {
   return {
     ...state,
@@ -606,7 +624,7 @@ export const connect = createReducer(defaultState, {
   [ActionTypes.ACCEPT_DISCLOSURE]: acceptDisclosure,
   [ActionTypes.CREATE_MEMBER_SUCCESS]: createMemberSuccess,
   [ActionTypes.CONNECT_COMPLETE]: connectComplete,
-  [ActionTypes.GO_BACK_CREDENTIALS]: connectGoBack,
+  [ActionTypes.GO_BACK_CREDENTIALS]: goBackCredentials,
   [ActionTypes.GO_BACK_CONSENT]: goBackSearchOrVerify,
   [ActionTypes.GO_BACK_POST_MESSAGE]: goBackSearchOrVerify,
   [ActionTypes.EXIT_MICRODEPOSITS]: exitMicrodeposits,

--- a/src/redux/reducers/__tests__/Connect-test.js
+++ b/src/redux/reducers/__tests__/Connect-test.js
@@ -924,7 +924,7 @@ describe('Connect redux store', () => {
   })
 
   describe('goBackCredentials', () => {
-    it('should go back to SEARCH', () => {
+    it('should go back to SEARCH when navigating back from credentials if VERIFY_EXISTING_MEMBER is available', () => {
       const beforeState = {
         members: [
           {
@@ -943,10 +943,7 @@ describe('Connect redux store', () => {
         type: ActionTypes.GO_BACK_CREDENTIALS,
       })
 
-      expect(afterState.location).toEqual([
-        { step: STEPS.VERIFY_EXISTING_MEMBER },
-        { step: STEPS.SEARCH },
-      ])
+      expect(afterState.location).toEqual([{ step: STEPS.SEARCH }])
     })
     it('should go back to SEARCH if VERIFY_EXISTING_MEMBER is not available', () => {
       const beforeState = {
@@ -965,6 +962,20 @@ describe('Connect redux store', () => {
           mode: VERIFY_MODE,
         },
       })
+
+      expect(afterState.location).toEqual([{ step: STEPS.SEARCH }])
+    })
+    it('should go back to SEARCH when navigating back from credentials after entering invalid credentials', () => {
+      const beforeState = {
+        ...defaultState,
+        location: [
+          { step: STEPS.SEARCH },
+          { step: STEPS.ENTER_CREDENTIALS },
+          { step: STEPS.CONNECTING },
+          { step: STEPS.ENTER_CREDENTIALS },
+        ],
+      }
+      const afterState = reducer(beforeState, { type: ActionTypes.GO_BACK_CREDENTIALS })
 
       expect(afterState.location).toEqual([{ step: STEPS.SEARCH }])
     })


### PR DESCRIPTION
Issue: [https://mxcom.atlassian.net/browse/CT-1682](https://mxcom.atlassian.net/browse/CT-1682)

###  Testing instructions

- Load connect in both aggregation and verification mode 
- On the credentials step, ensure that navigating back always takes you to the search screen, whether the credentials failed or not.
-  Ensure all tests are passing