### PR TITLE
fix: remove support handling from ActionableError and related tests

### DIFF
--- a/src/views/actionableError/__tests__/useActionableErrorMap-test.tsx
+++ b/src/views/actionableError/__tests__/useActionableErrorMap-test.tsx
@@ -84,7 +84,7 @@ describe('useActionableErrorMap', () => {
     })
     expect(screen.getByText('No accounts found')).toBeInTheDocument()
     expect(screen.getByText('Return to institution selection')).toBeInTheDocument()
-    expect(screen.queryByText('Get help')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('actionable-error-secondary-button')).not.toBeInTheDocument()
 
     const primaryButton = screen.getByText('Return to institution selection')
 
@@ -101,7 +101,7 @@ describe('useActionableErrorMap', () => {
     })
     expect(screen.getByText('Additional permissions needed')).toBeInTheDocument()
     expect(screen.getByText('Review instructions')).toBeInTheDocument()
-    expect(screen.queryByText('Get help')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('actionable-error-secondary-button')).not.toBeInTheDocument()
 
     const primaryButton = screen.getByText('Review instructions')
 
@@ -117,7 +117,7 @@ describe('useActionableErrorMap', () => {
     })
     expect(screen.getByText('Unable to connect')).toBeInTheDocument()
     expect(screen.getByText('Return to institution selection')).toBeInTheDocument()
-    expect(screen.queryByText('Get help')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('actionable-error-secondary-button')).not.toBeInTheDocument()
 
     const primaryButton = screen.getByText('Return to institution selection')
 
@@ -134,7 +134,7 @@ describe('useActionableErrorMap', () => {
     })
     expect(screen.getByText('Maintenance in progress')).toBeInTheDocument()
     expect(screen.getByText('Return to institution selection')).toBeInTheDocument()
-    expect(screen.queryByText('Get help')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('actionable-error-secondary-button')).not.toBeInTheDocument()
 
     const primaryButton = screen.getByText('Return to institution selection')
 
@@ -151,7 +151,7 @@ describe('useActionableErrorMap', () => {
     })
     expect(screen.getByText('Unable to connect')).toBeInTheDocument()
     expect(screen.getByText('Return to institution selection')).toBeInTheDocument()
-    expect(screen.queryByText('Get help')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('actionable-error-secondary-button')).not.toBeInTheDocument()
 
     const primaryButton = screen.getByText('Return to institution selection')
 


### PR DESCRIPTION
https://mxcom.atlassian.net/browse/CT-2159

#### Changes
- The support team has had a flood of issues that has happened due to AED having a ton of new needs supports buttons.
Removed those support buttons in AED view and will work with support and Jen when they return on how to roll that back out.