### PR TITLE
fix(test): add data-test id for the snackbar version message

### DIFF
--- a/src/views/search/Search.js
+++ b/src/views/search/Search.js
@@ -345,6 +345,7 @@ export const Search = React.forwardRef((_, navigationRef) => {
         {/* This version is a hidden feature unless a user is told how to find it */}
         <Snackbar
           autoHideDuration={6000}
+          data-test="snackbar-version-message"
           message={widgetVersion}
           onClose={() => setHeaderClicks(0)}
           open={headerClicks >= 5 && Boolean(widgetVersion)}


### PR DESCRIPTION
We need a test-id to help our tests be more reliable.  Previously we had to use MUI classes and that's not great.