### PR TITLE
fix: sort credential fields by display_order before rendering

### DIFF
--- a/src/views/credentials/Credentials.js
+++ b/src/views/credentials/Credentials.js
@@ -113,7 +113,7 @@ export const Credentials = React.forwardRef(
     const styles = getStyles(tokens, isSmall)
     const getNextDelay = getDelay(0, 100)
     const sortedCredentials = [...credentials].sort(
-      (a, b) => (a.display_order ?? 0) - (b.display_order ?? 0),
+      (a, b) => (a.display_order ?? Infinity) - (b.display_order ?? Infinity),
     )
     const initialValues = buildInitialValues(sortedCredentials)
     const formSchema = buildFormSchema(sortedCredentials)

--- a/src/views/credentials/Credentials.js
+++ b/src/views/credentials/Credentials.js
@@ -112,9 +112,12 @@ export const Credentials = React.forwardRef(
     const tokens = useTokens()
     const styles = getStyles(tokens, isSmall)
     const getNextDelay = getDelay(0, 100)
-    const initialValues = buildInitialValues(credentials)
-    const formSchema = buildFormSchema(credentials)
-    const loginFieldCount = credentials.length
+    const sortedCredentials = [...credentials].sort(
+      (a, b) => (a.display_order ?? 0) - (b.display_order ?? 0),
+    )
+    const initialValues = buildInitialValues(sortedCredentials)
+    const formSchema = buildFormSchema(sortedCredentials)
+    const loginFieldCount = sortedCredentials.length
     const showDisconnectOption =
       currentMember &&
       currentMember.is_managed_by_user &&
@@ -249,7 +252,7 @@ export const Credentials = React.forwardRef(
     const inputRefs = useRef({})
 
     useEffect(() => {
-      for (const field of credentials) {
+      for (const field of sortedCredentials) {
         if (errors[field.field_name]) {
           inputRefs.current[field.field_name]?.focus()
           break
@@ -258,7 +261,7 @@ export const Credentials = React.forwardRef(
     }, [errors])
 
     function attemptConnect() {
-      const credentialsPayload = credentials.map((credential) => {
+      const credentialsPayload = sortedCredentials.map((credential) => {
         return {
           guid: credential.guid,
           value: values[credential.field_name],
@@ -443,7 +446,7 @@ export const Credentials = React.forwardRef(
               onSubmit={(e) => e.preventDefault()}
               style={styles.form}
             >
-              {credentials.map((field) => (
+              {sortedCredentials.map((field) => (
                 <SlideDown delay={getNextDelay()} key={field.guid}>
                   {field.field_type === CREDENTIAL_FIELD_TYPES.PASSWORD ? (
                     <div style={errors[field.field_name] ? styles.passwordInputError : {}}>

--- a/src/views/credentials/Credentials.js
+++ b/src/views/credentials/Credentials.js
@@ -1,5 +1,6 @@
 import React, {
   Fragment,
+  useMemo,
   useRef,
   useState,
   useEffect,
@@ -112,8 +113,9 @@ export const Credentials = React.forwardRef(
     const tokens = useTokens()
     const styles = getStyles(tokens, isSmall)
     const getNextDelay = getDelay(0, 100)
-    const sortedCredentials = [...credentials].sort(
-      (a, b) => (a.display_order ?? Infinity) - (b.display_order ?? Infinity),
+    const sortedCredentials = useMemo(
+      () => [...credentials].sort((a, b) => (a.display_order ?? Infinity) - (b.display_order ?? Infinity)),
+      [credentials],
     )
     const initialValues = buildInitialValues(sortedCredentials)
     const formSchema = buildFormSchema(sortedCredentials)

--- a/src/views/credentials/__tests__/Credentials-test.tsx
+++ b/src/views/credentials/__tests__/Credentials-test.tsx
@@ -144,8 +144,20 @@ describe('Credentials', () => {
     const reversedCredentialProps = {
       ...credentialProps,
       credentials: [
-        { guid: 'CRD-456', label: 'Password', field_name: 'password', field_type: 1, display_order: 2 },
-        { guid: 'CRD-123', label: 'Username', field_name: 'username', field_type: 3, display_order: 1 },
+        {
+          guid: 'CRD-456',
+          label: 'Password',
+          field_name: 'password',
+          field_type: 1,
+          display_order: 2,
+        },
+        {
+          guid: 'CRD-123',
+          label: 'Username',
+          field_name: 'username',
+          field_type: 3,
+          display_order: 1,
+        },
       ],
     }
     const ref = React.createRef()
@@ -155,7 +167,42 @@ describe('Credentials', () => {
 
     const usernameField = await screen.findByLabelText(/Enter your Username/i)
     const passwordField = await screen.findByLabelText(/Password/i)
-    expect(usernameField.compareDocumentPosition(passwordField) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    const passwordFollowsUsername =
+      usernameField.compareDocumentPosition(passwordField) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+    expect(passwordFollowsUsername).toBeTruthy()
+  })
+
+  it('sorts credentials without display_order to the end', async () => {
+    const mixedCredentialProps = {
+      ...credentialProps,
+      credentials: [
+        {
+          guid: 'CRD-789',
+          label: 'PIN',
+          field_name: 'pin',
+          field_type: 3,
+        },
+        {
+          guid: 'CRD-123',
+          label: 'Username',
+          field_name: 'username',
+          field_type: 3,
+          display_order: 1,
+        },
+      ],
+    }
+    const ref = React.createRef()
+    render(<Credentials {...mixedCredentialProps} ref={ref} />, {
+      preloadedState: initialStateCopy,
+    })
+
+    const usernameField = await screen.findByLabelText(/Enter your Username/i)
+    const pinField = await screen.findByLabelText(/Enter your PIN/i)
+    const pinFollowsUsername =
+      usernameField.compareDocumentPosition(pinField) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+    expect(pinFollowsUsername).toBeTruthy()
   })
 
   it('renders credentials and makes sure that the powered by MX footer is not present', () => {

--- a/src/views/credentials/__tests__/Credentials-test.tsx
+++ b/src/views/credentials/__tests__/Credentials-test.tsx
@@ -140,6 +140,23 @@ describe('Credentials', () => {
       expect(screen.getByText('Data access by')).toBeInTheDocument()
     })
   })
+  it('renders credentials in display_order regardless of API response order', async () => {
+    const reversedCredentialProps = {
+      ...credentialProps,
+      credentials: [
+        { guid: 'CRD-456', label: 'Password', field_name: 'password', field_type: 1, display_order: 2 },
+        { guid: 'CRD-123', label: 'Username', field_name: 'username', field_type: 3, display_order: 1 },
+      ],
+    }
+    const ref = React.createRef()
+    render(<Credentials {...reversedCredentialProps} ref={ref} />, {
+      preloadedState: initialStateCopy,
+    })
+
+    const inputs = await screen.findAllByRole('textbox')
+    expect(inputs[0]).toHaveAccessibleName(/Username/i)
+  })
+
   it('renders credentials and makes sure that the powered by MX footer is not present', () => {
     const ref = React.createRef()
     render(<Credentials {...credentialProps} ref={ref} />, { preloadedState: initialStateCopy })

--- a/src/views/credentials/__tests__/Credentials-test.tsx
+++ b/src/views/credentials/__tests__/Credentials-test.tsx
@@ -153,8 +153,9 @@ describe('Credentials', () => {
       preloadedState: initialStateCopy,
     })
 
-    const inputs = await screen.findAllByRole('textbox')
-    expect(inputs[0]).toHaveAccessibleName(/Username/i)
+    const usernameField = await screen.findByLabelText(/Enter your Username/i)
+    const passwordField = await screen.findByLabelText(/Password/i)
+    expect(usernameField.compareDocumentPosition(passwordField) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('renders credentials and makes sure that the powered by MX footer is not present', () => {


### PR DESCRIPTION
## Summary

When connecting to MX Bank (test institution), the password field renders above the username field. This happens because the `Credentials` component renders fields in whatever order the API returns them, without sorting by `display_order`.

## Changes

- Sort credentials by `display_order` in `Credentials.js` before rendering, building form schema, and building initial values
- Handles missing `display_order` gracefully (defaults to 0)
- The fix is in the shared `Credentials` component so both `CreateMemberForm` and `UpdateMemberForm` benefit
- Added a test verifying that credentials render in `display_order` regardless of API response order

## Root cause

`Credentials.js` uses `credentials.map(...)` directly for rendering (line 446), `buildInitialValues` (line 115), `buildFormSchema` (line 116), and `attemptConnect` (line 261) — all without sorting by `display_order`. When the MX Platform API returns credentials with password before username in the array, the widget displays them in that order.

## Fix

```javascript
const sortedCredentials = [...credentials].sort(
  (a, b) => (a.display_order ?? 0) - (b.display_order ?? 0),
)
```

All references to `credentials` within the component now use `sortedCredentials`.

## Test plan

- [x] Added test: credentials with reversed API order render correctly by `display_order`
- [ ] Manual verification with MX Bank (test institution) — password/username should now appear in correct order